### PR TITLE
Fix flaky MongoDB connection

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - /app/node_modules
     ports:
       - 5000:5000
+    dns:
+      - 8.8.8.8
   frontend:
     build:
       context: ./frontend


### PR DESCRIPTION
Encountered some flakiness with the DB connection through mongoose today, using Google's public DNS server seems to help.